### PR TITLE
Changed tests configuration to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ python3 src/ensembl/production/metadata/service.py
 
 Start the client script
 ```
-python3 src/ensembl/production/metadata/client_examples.py
+PYTHONPATH='src' python3 src/ensembl/production/metadata/client_examples.py
 ```
 
 ### Testing
@@ -81,7 +81,7 @@ python3 src/ensembl/production/metadata/client_examples.py
 Run test suite:
 ```
 cd ensembl-metadata-service
-pytest
+PYTHONPATH='src' pytest
 ```
 
 To run tests, calculate and display testing coverage stats:

--- a/src/ensembl/production/metadata/service.py
+++ b/src/ensembl/production/metadata/service.py
@@ -146,7 +146,8 @@ def get_species_information(metadata_db, taxonomy_db, genome_uuid):
             organism.c.display_name,
             organism.c.taxonomy_id,
             organism.c.scientific_name,
-            organism.c.strain
+            organism.c.strain,
+            organism.c.scientific_parlance_name
         ).select_from(genome).filter_by(
             genome_uuid=genome_uuid
         ).join(organism)
@@ -273,6 +274,7 @@ def get_genome_by_uuid(metadata_db, genome_uuid):
             organism.c.taxonomy_id,
             organism.c.scientific_name,
             organism.c.strain,
+            organism.c.scientific_parlance_name,
             assembly.c.accession.label('assembly_accession'),
             assembly.c.name.label('assembly_name'),
             assembly.c.ucsc_name.label('assembly_ucsc_name'),
@@ -325,6 +327,7 @@ def get_genome_by_name(metadata_db, ensembl_name, site_name, release_version):
             organism.c.taxonomy_id,
             organism.c.scientific_name,
             organism.c.strain,
+            organism.c.scientific_parlance_name,
             assembly.c.accession.label('assembly_accession'),
             assembly.c.name.label('assembly_name'),
             assembly.c.ucsc_name.label('assembly_ucsc_name'),
@@ -457,7 +460,8 @@ def create_species(data=None):
         ncbi_common_name=data['ncbi_common_name'],
         scientific_name=data['scientific_name'],
         alternative_names=data['alternative_names'],
-        taxon_id=data['taxonomy_id']
+        taxon_id=data['taxonomy_id'],
+        scientific_parlance_name=data['scientific_parlance_name']
     )
     return species
     # return json_format.MessageToJson(species)

--- a/src/ensembl/production/metadata/service.py
+++ b/src/ensembl/production/metadata/service.py
@@ -146,8 +146,7 @@ def get_species_information(metadata_db, taxonomy_db, genome_uuid):
             organism.c.display_name,
             organism.c.taxonomy_id,
             organism.c.scientific_name,
-            organism.c.strain,
-            organism.c.scientific_parlance_name
+            organism.c.strain
         ).select_from(genome).filter_by(
             genome_uuid=genome_uuid
         ).join(organism)
@@ -163,6 +162,7 @@ def get_species_information(metadata_db, taxonomy_db, genome_uuid):
         taxo_results = session.execute(tax_names).all()
         common_names = []
         # Get the common name and alternative names
+        species_data['ncbi_common_name'] = None
         if len(taxo_results) > 0:
             for item in taxo_results:
                 if item[1] is not None and item[0] is not None:
@@ -273,7 +273,6 @@ def get_genome_by_uuid(metadata_db, genome_uuid):
             organism.c.taxonomy_id,
             organism.c.scientific_name,
             organism.c.strain,
-            organism.c.scientific_parlance_name,
             assembly.c.accession.label('assembly_accession'),
             assembly.c.name.label('assembly_name'),
             assembly.c.ucsc_name.label('assembly_ucsc_name'),
@@ -326,7 +325,6 @@ def get_genome_by_name(metadata_db, ensembl_name, site_name, release_version):
             organism.c.taxonomy_id,
             organism.c.scientific_name,
             organism.c.strain,
-            organism.c.scientific_parlance_name,
             assembly.c.accession.label('assembly_accession'),
             assembly.c.name.label('assembly_name'),
             assembly.c.ucsc_name.label('assembly_ucsc_name'),
@@ -459,8 +457,7 @@ def create_species(data=None):
         ncbi_common_name=data['ncbi_common_name'],
         scientific_name=data['scientific_name'],
         alternative_names=data['alternative_names'],
-        taxon_id=data['taxonomy_id'],
-        scientific_parlance_name=data['scientific_parlance_name']
+        taxon_id=data['taxonomy_id']
     )
     return species
     # return json_format.MessageToJson(species)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -142,7 +142,6 @@ class TestClass:
             'ncbi_common_name': 'cattle',
             'scientific_name': 'Bos taurus',
             'alternative_names': ["bovine", "cow", "dairy cow", "domestic cattle", "domestic cow"],
-            'scientific_parlance_name': 'Bos taurus',
             'taxonomy_id': 9913
         }
 
@@ -151,7 +150,6 @@ class TestClass:
             'commonName': 'cow',
             'ncbiCommonName': 'cattle',
             'scientificName': 'Bos taurus',
-            'scientificParlanceName': 'Bos taurus',
             'alternativeNames': ["bovine", "cow", "dairy cow", "domestic cattle", "domestic cow"],
             'taxonId': 9913
         }

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -142,6 +142,7 @@ class TestClass:
             'ncbi_common_name': 'cattle',
             'scientific_name': 'Bos taurus',
             'alternative_names': ["bovine", "cow", "dairy cow", "domestic cattle", "domestic cow"],
+            'scientific_parlance_name': 'Bos taurus',
             'taxonomy_id': 9913
         }
 
@@ -150,6 +151,7 @@ class TestClass:
             'commonName': 'cow',
             'ncbiCommonName': 'cattle',
             'scientificName': 'Bos taurus',
+            'scientificParlanceName': 'Bos taurus',
             'alternativeNames': ["bovine", "cow", "dairy cow", "domestic cattle", "domestic cow"],
             'taxonId': 9913
         }


### PR DESCRIPTION
This change fixes some issues that came up when I was trying to get the tests running.  

1. The 'scientific_parlance_name' doesn't exist in the ensembl_metadata/organism database so I removed it from the service code, but left it in the proto file for backwards-compatibility.
2. One of the examples in the `client_examples.py` file doesn't have a `genbank common name`, so it doesn't get assigned an `ncbi_common_name` on line 170 of `service.py`, and so we throw an error [here](https://github.com/Ensembl/ensembl-metadata-service/blob/main/src/ensembl/production/metadata/service.py#L459).  I've added a default value of `None` for `ncbi_common_name`.
3. I had to set the `PYTHONPATH` in order to recognise imports.
