### PR TITLE
Add method to get dataset info by genomeid and datatype

### DIFF
--- a/protos/ensembl_metadata.proto
+++ b/protos/ensembl_metadata.proto
@@ -141,7 +141,7 @@ message Release {
 }
 
 /*
-Wrapper for a list of DatasetInfos
+Wrapper for a list of DatasetInfo objects
 */
 message DatasetInfos {
   string genome_uuid = 1;

--- a/protos/ensembl_metadata.proto
+++ b/protos/ensembl_metadata.proto
@@ -36,6 +36,9 @@ service EnsemblMetadata {
 
   // Retrieve sequence metadata for a genome's assembly.
   rpc GetGenomeSequence(GenomeSequenceRequest) returns (stream GenomeSequence) {}
+
+  // Retrieve dataset info by genome uuid and dataset_type
+  rpc GetDatasetInformation(GenomeDatatypeRequest) returns (DatasetInfos) {}
 }
 
 /*
@@ -138,6 +141,28 @@ message Release {
 }
 
 /*
+Wrapper for a list of DatasetInfos
+*/
+message DatasetInfos {
+  string genome_uuid = 1;
+  string dataset_type = 2;
+  /*
+  Details for datasets
+  */
+  message DatasetInfo {
+    string dataset_uuid = 1;
+    string dataset_name = 2;
+    string name = 3;
+    string type = 4;
+    string dataset_version = 5;
+    string dataset_label = 6;
+    uint32 version = 7;
+    string value = 8;
+  }
+  repeated DatasetInfo dataset_infos = 3;
+}
+
+/*
 Metadata about the sequences that comprise a genome's assembly.
  */
 message GenomeSequence {
@@ -198,4 +223,12 @@ Genome sequence filter.
 message GenomeSequenceRequest {
   string genome_uuid = 1;     // Mandatory
   bool chromosomal_only = 2;  // Optional
+}
+
+/*
+Genome datatype filter
+*/
+message GenomeDatatypeRequest {
+  string genome_uuid = 1;     // Mandatory
+  string dataset_type = 2;    // Mandatory
 }

--- a/src/ensembl/production/metadata/client_examples.py
+++ b/src/ensembl/production/metadata/client_examples.py
@@ -149,7 +149,7 @@ def get_top_level_statistics(stub):
     print(releases1)
 
 
-def get_dataset_infos(stub):
+def get_dataset_infos_by_dataset_type(stub):
     request1 = GenomeDatatypeRequest(genome_uuid="a7335667-93e7-11ec-a39d-005056b38ce3", dataset_type="geneset")
     datasets1 = stub.GetDatasetInformation(request1)
     print(datasets1.dataset_infos)
@@ -179,7 +179,7 @@ def run():
         print("-------------- List Releases for Genome --------------")
         list_releases_by_uuid(stub)
         print("-------------- List Dataset information for Genome --------------")
-        get_dataset_infos(stub)
+        get_dataset_infos_by_dataset_type(stub)
 
 
 if __name__ == '__main__':

--- a/src/ensembl/production/metadata/client_examples.py
+++ b/src/ensembl/production/metadata/client_examples.py
@@ -4,7 +4,7 @@ import logging
 from ensembl_metadata_pb2 import \
     GenomeUUIDRequest, GenomeNameRequest, \
     ReleaseRequest, GenomeSequenceRequest, AssemblyIDRequest, \
-    OrganismIDRequest
+    OrganismIDRequest, GenomeDatatypeRequest
 
 import ensembl.production.metadata.ensembl_metadata_pb2_grpc as ensembl_metadata_pb2_grpc
 
@@ -149,6 +149,12 @@ def get_top_level_statistics(stub):
     print(releases1)
 
 
+def get_dataset_infos(stub):
+    request1 = GenomeDatatypeRequest(genome_uuid="a7335667-93e7-11ec-a39d-005056b38ce3", dataset_type="geneset")
+    datasets1 = stub.GetDatasetInformation(request1)
+    print(datasets1.dataset_infos)
+
+
 def run():
     with grpc.insecure_channel('localhost:50051') as channel:
         stub = ensembl_metadata_pb2_grpc.EnsemblMetadataStub(channel)
@@ -172,6 +178,8 @@ def run():
         list_releases(stub)
         print("-------------- List Releases for Genome --------------")
         list_releases_by_uuid(stub)
+        print("-------------- List Dataset information for Genome --------------")
+        get_dataset_infos(stub)
 
 
 if __name__ == '__main__':

--- a/src/ensembl/production/metadata/ensembl_metadata_pb2.py
+++ b/src/ensembl/production/metadata/ensembl_metadata_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x16\x65nsembl_metadata.proto\x12\x10\x65nsembl_metadata\"\xc5\x01\n\x06Genome\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\x12\x14\n\x0c\x65nsembl_name\x18\x02 \x01(\t\x12\x10\n\x08url_name\x18\x03 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x04 \x01(\t\x12\x12\n\nis_current\x18\x05 \x01(\x08\x12,\n\x08\x61ssembly\x18\x06 \x01(\x0b\x32\x1a.ensembl_metadata.Assembly\x12&\n\x05taxon\x18\x07 \x01(\x0b\x32\x17.ensembl_metadata.Taxon\"U\n\tKaryotype\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x13\n\x0b\x63hromosomal\x18\x02 \x01(\t\x12\x10\n\x08location\x18\x03 \x01(\t\x12\x13\n\x0bgenome_uuid\x18\x04 \x01(\t\"\xb5\x01\n\x07Species\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\x12\x13\n\x0b\x63ommon_name\x18\x02 \x01(\t\x12\x18\n\x10ncbi_common_name\x18\x04 \x01(\t\x12\x10\n\x08taxon_id\x18\x05 \x01(\r\x12\x17\n\x0fscientific_name\x18\x06 \x01(\t\x12\x19\n\x11\x61lternative_names\x18\x07 \x03(\t\x12 \n\x18scientific_parlance_name\x18\x08 \x01(\t\"\xc8\x01\n\x0c\x41ssemblyInfo\x12\x13\n\x0b\x61ssembly_id\x18\x01 \x01(\t\x12\x11\n\taccession\x18\x02 \x01(\t\x12\r\n\x05level\x18\x03 \x01(\t\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x13\n\x0b\x63hromosomal\x18\x05 \x01(\r\x12\x0e\n\x06length\x18\x06 \x01(\r\x12\x19\n\x11sequence_location\x18\x07 \x01(\t\x12\x19\n\x11sequence_checksum\x18\x08 \x01(\t\x12\x18\n\x10ga4gh_identifier\x18\t \x01(\t\"M\n\nSubSpecies\x12\x13\n\x0borganism_id\x18\x01 \x01(\t\x12\x14\n\x0cspecies_type\x18\x02 \x03(\t\x12\x14\n\x0cspecies_name\x18\x03 \x03(\t\"K\n\x08Grouping\x12\x13\n\x0borganism_id\x18\x01 \x01(\t\x12\x14\n\x0cspecies_type\x18\x02 \x03(\t\x12\x14\n\x0cspecies_name\x18\x03 \x03(\t\"\xdc\x01\n\x12TopLevelStatistics\x12\x13\n\x0borganism_id\x18\x01 \x01(\t\x12L\n\nstatistics\x18\x02 \x03(\x0b\x32\x38.ensembl_metadata.TopLevelStatistics.AttributeStatistics\x1a\x63\n\x13\x41ttributeStatistics\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\r\n\x05label\x18\x03 \x01(\t\x12\x16\n\x0estatistic_type\x18\x04 \x01(\t\x12\x17\n\x0fstatistic_value\x18\x05 \x01(\t\"M\n\x08\x41ssembly\x12\x11\n\taccession\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tucsc_name\x18\x03 \x01(\t\x12\r\n\x05level\x18\x04 \x01(\t\"Z\n\x05Taxon\x12\x13\n\x0btaxonomy_id\x18\x01 \x01(\r\x12\x17\n\x0fscientific_name\x18\x02 \x01(\t\x12\x0e\n\x06strain\x18\x03 \x01(\t\x12\x13\n\x0b\x63ommon_name\x18\x04 \x03(\t\"\x9c\x01\n\x07Release\x12\x17\n\x0frelease_version\x18\x01 \x01(\r\x12\x14\n\x0crelease_date\x18\x02 \x01(\t\x12\x15\n\rrelease_label\x18\x03 \x01(\t\x12\x12\n\nis_current\x18\x04 \x01(\x08\x12\x11\n\tsite_name\x18\x05 \x01(\t\x12\x12\n\nsite_label\x18\x06 \x01(\t\x12\x10\n\x08site_uri\x18\x07 \x01(\t\"q\n\x0eGenomeSequence\x12\x11\n\taccession\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11sequence_location\x18\x03 \x01(\t\x12\x0e\n\x06length\x18\x04 \x01(\r\x12\x13\n\x0b\x63hromosomal\x18\x05 \x01(\x08\"(\n\x11GenomeUUIDRequest\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\"(\n\x11\x41ssemblyIDRequest\x12\x13\n\x0b\x61ssembly_id\x18\x01 \x01(\t\"(\n\x11OrganismIDRequest\x12\x13\n\x0borganism_id\x18\x01 \x01(\t\"U\n\x11GenomeNameRequest\x12\x14\n\x0c\x65nsembl_name\x18\x01 \x01(\t\x12\x11\n\tsite_name\x18\x02 \x01(\t\x12\x17\n\x0frelease_version\x18\x03 \x01(\r\"R\n\x0eReleaseRequest\x12\x11\n\tsite_name\x18\x01 \x03(\t\x12\x17\n\x0frelease_version\x18\x02 \x03(\r\x12\x14\n\x0c\x63urrent_only\x18\x03 \x01(\x08\"F\n\x15GenomeSequenceRequest\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\x12\x18\n\x10\x63hromosomal_only\x18\x02 \x01(\x08\x32\x83\x08\n\x0f\x45nsemblMetadata\x12R\n\x0fGetGenomeByUUID\x12#.ensembl_metadata.GenomeUUIDRequest\x1a\x18.ensembl_metadata.Genome\"\x00\x12Y\n\x15GetSpeciesInformation\x12#.ensembl_metadata.GenomeUUIDRequest\x1a\x19.ensembl_metadata.Species\"\x00\x12_\n\x16GetAssemblyInformation\x12#.ensembl_metadata.AssemblyIDRequest\x1a\x1e.ensembl_metadata.AssemblyInfo\"\x00\x12_\n\x18GetSubSpeciesInformation\x12#.ensembl_metadata.OrganismIDRequest\x1a\x1c.ensembl_metadata.SubSpecies\"\x00\x12[\n\x16GetGroupingInformation\x12#.ensembl_metadata.OrganismIDRequest\x1a\x1a.ensembl_metadata.Grouping\"\x00\x12]\n\x17GetKaryotypeInformation\x12#.ensembl_metadata.GenomeUUIDRequest\x1a\x1b.ensembl_metadata.Karyotype\"\x00\x12\x64\n\x15GetTopLevelStatistics\x12#.ensembl_metadata.OrganismIDRequest\x1a$.ensembl_metadata.TopLevelStatistics\"\x00\x12R\n\x0fGetGenomeByName\x12#.ensembl_metadata.GenomeNameRequest\x1a\x18.ensembl_metadata.Genome\"\x00\x12M\n\nGetRelease\x12 .ensembl_metadata.ReleaseRequest\x1a\x19.ensembl_metadata.Release\"\x00\x30\x01\x12V\n\x10GetReleaseByUUID\x12#.ensembl_metadata.GenomeUUIDRequest\x1a\x19.ensembl_metadata.Release\"\x00\x30\x01\x12\x62\n\x11GetGenomeSequence\x12\'.ensembl_metadata.GenomeSequenceRequest\x1a .ensembl_metadata.GenomeSequence\"\x00\x30\x01\x62\x06proto3'
+  serialized_pb=b'\n\x16\x65nsembl_metadata.proto\x12\x10\x65nsembl_metadata\"\xc5\x01\n\x06Genome\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\x12\x14\n\x0c\x65nsembl_name\x18\x02 \x01(\t\x12\x10\n\x08url_name\x18\x03 \x01(\t\x12\x14\n\x0c\x64isplay_name\x18\x04 \x01(\t\x12\x12\n\nis_current\x18\x05 \x01(\x08\x12,\n\x08\x61ssembly\x18\x06 \x01(\x0b\x32\x1a.ensembl_metadata.Assembly\x12&\n\x05taxon\x18\x07 \x01(\x0b\x32\x17.ensembl_metadata.Taxon\"U\n\tKaryotype\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x13\n\x0b\x63hromosomal\x18\x02 \x01(\t\x12\x10\n\x08location\x18\x03 \x01(\t\x12\x13\n\x0bgenome_uuid\x18\x04 \x01(\t\"\xb5\x01\n\x07Species\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\x12\x13\n\x0b\x63ommon_name\x18\x02 \x01(\t\x12\x18\n\x10ncbi_common_name\x18\x04 \x01(\t\x12\x10\n\x08taxon_id\x18\x05 \x01(\r\x12\x17\n\x0fscientific_name\x18\x06 \x01(\t\x12\x19\n\x11\x61lternative_names\x18\x07 \x03(\t\x12 \n\x18scientific_parlance_name\x18\x08 \x01(\t\"\xc8\x01\n\x0c\x41ssemblyInfo\x12\x13\n\x0b\x61ssembly_id\x18\x01 \x01(\t\x12\x11\n\taccession\x18\x02 \x01(\t\x12\r\n\x05level\x18\x03 \x01(\t\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x13\n\x0b\x63hromosomal\x18\x05 \x01(\r\x12\x0e\n\x06length\x18\x06 \x01(\r\x12\x19\n\x11sequence_location\x18\x07 \x01(\t\x12\x19\n\x11sequence_checksum\x18\x08 \x01(\t\x12\x18\n\x10ga4gh_identifier\x18\t \x01(\t\"M\n\nSubSpecies\x12\x13\n\x0borganism_id\x18\x01 \x01(\t\x12\x14\n\x0cspecies_type\x18\x02 \x03(\t\x12\x14\n\x0cspecies_name\x18\x03 \x03(\t\"K\n\x08Grouping\x12\x13\n\x0borganism_id\x18\x01 \x01(\t\x12\x14\n\x0cspecies_type\x18\x02 \x03(\t\x12\x14\n\x0cspecies_name\x18\x03 \x03(\t\"\xdc\x01\n\x12TopLevelStatistics\x12\x13\n\x0borganism_id\x18\x01 \x01(\t\x12L\n\nstatistics\x18\x02 \x03(\x0b\x32\x38.ensembl_metadata.TopLevelStatistics.AttributeStatistics\x1a\x63\n\x13\x41ttributeStatistics\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\r\n\x05label\x18\x03 \x01(\t\x12\x16\n\x0estatistic_type\x18\x04 \x01(\t\x12\x17\n\x0fstatistic_value\x18\x05 \x01(\t\"M\n\x08\x41ssembly\x12\x11\n\taccession\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tucsc_name\x18\x03 \x01(\t\x12\r\n\x05level\x18\x04 \x01(\t\"Z\n\x05Taxon\x12\x13\n\x0btaxonomy_id\x18\x01 \x01(\r\x12\x17\n\x0fscientific_name\x18\x02 \x01(\t\x12\x0e\n\x06strain\x18\x03 \x01(\t\x12\x13\n\x0b\x63ommon_name\x18\x04 \x03(\t\"\x9c\x01\n\x07Release\x12\x17\n\x0frelease_version\x18\x01 \x01(\r\x12\x14\n\x0crelease_date\x18\x02 \x01(\t\x12\x15\n\rrelease_label\x18\x03 \x01(\t\x12\x12\n\nis_current\x18\x04 \x01(\x08\x12\x11\n\tsite_name\x18\x05 \x01(\t\x12\x12\n\nsite_label\x18\x06 \x01(\t\x12\x10\n\x08site_uri\x18\x07 \x01(\t\"\xa4\x02\n\x0c\x44\x61tasetInfos\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\x12\x14\n\x0c\x64\x61taset_type\x18\x02 \x01(\t\x12\x41\n\rdataset_infos\x18\x03 \x03(\x0b\x32*.ensembl_metadata.DatasetInfos.DatasetInfo\x1a\xa5\x01\n\x0b\x44\x61tasetInfo\x12\x14\n\x0c\x64\x61taset_uuid\x18\x01 \x01(\t\x12\x14\n\x0c\x64\x61taset_name\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x0c\n\x04type\x18\x04 \x01(\t\x12\x17\n\x0f\x64\x61taset_version\x18\x05 \x01(\t\x12\x15\n\rdataset_label\x18\x06 \x01(\t\x12\x0f\n\x07version\x18\x07 \x01(\r\x12\r\n\x05value\x18\x08 \x01(\t\"q\n\x0eGenomeSequence\x12\x11\n\taccession\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11sequence_location\x18\x03 \x01(\t\x12\x0e\n\x06length\x18\x04 \x01(\r\x12\x13\n\x0b\x63hromosomal\x18\x05 \x01(\x08\"(\n\x11GenomeUUIDRequest\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\"(\n\x11\x41ssemblyIDRequest\x12\x13\n\x0b\x61ssembly_id\x18\x01 \x01(\t\"(\n\x11OrganismIDRequest\x12\x13\n\x0borganism_id\x18\x01 \x01(\t\"U\n\x11GenomeNameRequest\x12\x14\n\x0c\x65nsembl_name\x18\x01 \x01(\t\x12\x11\n\tsite_name\x18\x02 \x01(\t\x12\x17\n\x0frelease_version\x18\x03 \x01(\r\"R\n\x0eReleaseRequest\x12\x11\n\tsite_name\x18\x01 \x03(\t\x12\x17\n\x0frelease_version\x18\x02 \x03(\r\x12\x14\n\x0c\x63urrent_only\x18\x03 \x01(\x08\"F\n\x15GenomeSequenceRequest\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\x12\x18\n\x10\x63hromosomal_only\x18\x02 \x01(\x08\"B\n\x15GenomeDatatypeRequest\x12\x13\n\x0bgenome_uuid\x18\x01 \x01(\t\x12\x14\n\x0c\x64\x61taset_type\x18\x02 \x01(\t2\xe7\x08\n\x0f\x45nsemblMetadata\x12R\n\x0fGetGenomeByUUID\x12#.ensembl_metadata.GenomeUUIDRequest\x1a\x18.ensembl_metadata.Genome\"\x00\x12Y\n\x15GetSpeciesInformation\x12#.ensembl_metadata.GenomeUUIDRequest\x1a\x19.ensembl_metadata.Species\"\x00\x12_\n\x16GetAssemblyInformation\x12#.ensembl_metadata.AssemblyIDRequest\x1a\x1e.ensembl_metadata.AssemblyInfo\"\x00\x12_\n\x18GetSubSpeciesInformation\x12#.ensembl_metadata.OrganismIDRequest\x1a\x1c.ensembl_metadata.SubSpecies\"\x00\x12[\n\x16GetGroupingInformation\x12#.ensembl_metadata.OrganismIDRequest\x1a\x1a.ensembl_metadata.Grouping\"\x00\x12]\n\x17GetKaryotypeInformation\x12#.ensembl_metadata.GenomeUUIDRequest\x1a\x1b.ensembl_metadata.Karyotype\"\x00\x12\x64\n\x15GetTopLevelStatistics\x12#.ensembl_metadata.OrganismIDRequest\x1a$.ensembl_metadata.TopLevelStatistics\"\x00\x12R\n\x0fGetGenomeByName\x12#.ensembl_metadata.GenomeNameRequest\x1a\x18.ensembl_metadata.Genome\"\x00\x12M\n\nGetRelease\x12 .ensembl_metadata.ReleaseRequest\x1a\x19.ensembl_metadata.Release\"\x00\x30\x01\x12V\n\x10GetReleaseByUUID\x12#.ensembl_metadata.GenomeUUIDRequest\x1a\x19.ensembl_metadata.Release\"\x00\x30\x01\x12\x62\n\x11GetGenomeSequence\x12\'.ensembl_metadata.GenomeSequenceRequest\x1a .ensembl_metadata.GenomeSequence\"\x00\x30\x01\x12\x62\n\x15GetDatasetInformation\x12\'.ensembl_metadata.GenomeDatatypeRequest\x1a\x1e.ensembl_metadata.DatasetInfos\"\x00\x62\x06proto3'
 )
 
 
@@ -677,6 +677,132 @@ _RELEASE = _descriptor.Descriptor(
 )
 
 
+_DATASETINFOS_DATASETINFO = _descriptor.Descriptor(
+  name='DatasetInfo',
+  full_name='ensembl_metadata.DatasetInfos.DatasetInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='dataset_uuid', full_name='ensembl_metadata.DatasetInfos.DatasetInfo.dataset_uuid', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dataset_name', full_name='ensembl_metadata.DatasetInfos.DatasetInfo.dataset_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='name', full_name='ensembl_metadata.DatasetInfos.DatasetInfo.name', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='type', full_name='ensembl_metadata.DatasetInfos.DatasetInfo.type', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dataset_version', full_name='ensembl_metadata.DatasetInfos.DatasetInfo.dataset_version', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dataset_label', full_name='ensembl_metadata.DatasetInfos.DatasetInfo.dataset_label', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='ensembl_metadata.DatasetInfos.DatasetInfo.version', index=6,
+      number=7, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='ensembl_metadata.DatasetInfos.DatasetInfo.value', index=7,
+      number=8, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1555,
+  serialized_end=1720,
+)
+
+_DATASETINFOS = _descriptor.Descriptor(
+  name='DatasetInfos',
+  full_name='ensembl_metadata.DatasetInfos',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='genome_uuid', full_name='ensembl_metadata.DatasetInfos.genome_uuid', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dataset_type', full_name='ensembl_metadata.DatasetInfos.dataset_type', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dataset_infos', full_name='ensembl_metadata.DatasetInfos.dataset_infos', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[_DATASETINFOS_DATASETINFO, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1428,
+  serialized_end=1720,
+)
+
+
 _GENOMESEQUENCE = _descriptor.Descriptor(
   name='GenomeSequence',
   full_name='ensembl_metadata.GenomeSequence',
@@ -732,8 +858,8 @@ _GENOMESEQUENCE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1427,
-  serialized_end=1540,
+  serialized_start=1722,
+  serialized_end=1835,
 )
 
 
@@ -764,8 +890,8 @@ _GENOMEUUIDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1542,
-  serialized_end=1582,
+  serialized_start=1837,
+  serialized_end=1877,
 )
 
 
@@ -796,8 +922,8 @@ _ASSEMBLYIDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1584,
-  serialized_end=1624,
+  serialized_start=1879,
+  serialized_end=1919,
 )
 
 
@@ -828,8 +954,8 @@ _ORGANISMIDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1626,
-  serialized_end=1666,
+  serialized_start=1921,
+  serialized_end=1961,
 )
 
 
@@ -874,8 +1000,8 @@ _GENOMENAMEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1668,
-  serialized_end=1753,
+  serialized_start=1963,
+  serialized_end=2048,
 )
 
 
@@ -920,8 +1046,8 @@ _RELEASEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1755,
-  serialized_end=1837,
+  serialized_start=2050,
+  serialized_end=2132,
 )
 
 
@@ -959,14 +1085,55 @@ _GENOMESEQUENCEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1839,
-  serialized_end=1909,
+  serialized_start=2134,
+  serialized_end=2204,
+)
+
+
+_GENOMEDATATYPEREQUEST = _descriptor.Descriptor(
+  name='GenomeDatatypeRequest',
+  full_name='ensembl_metadata.GenomeDatatypeRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='genome_uuid', full_name='ensembl_metadata.GenomeDatatypeRequest.genome_uuid', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dataset_type', full_name='ensembl_metadata.GenomeDatatypeRequest.dataset_type', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2206,
+  serialized_end=2272,
 )
 
 _GENOME.fields_by_name['assembly'].message_type = _ASSEMBLY
 _GENOME.fields_by_name['taxon'].message_type = _TAXON
 _TOPLEVELSTATISTICS_ATTRIBUTESTATISTICS.containing_type = _TOPLEVELSTATISTICS
 _TOPLEVELSTATISTICS.fields_by_name['statistics'].message_type = _TOPLEVELSTATISTICS_ATTRIBUTESTATISTICS
+_DATASETINFOS_DATASETINFO.containing_type = _DATASETINFOS
+_DATASETINFOS.fields_by_name['dataset_infos'].message_type = _DATASETINFOS_DATASETINFO
 DESCRIPTOR.message_types_by_name['Genome'] = _GENOME
 DESCRIPTOR.message_types_by_name['Karyotype'] = _KARYOTYPE
 DESCRIPTOR.message_types_by_name['Species'] = _SPECIES
@@ -977,6 +1144,7 @@ DESCRIPTOR.message_types_by_name['TopLevelStatistics'] = _TOPLEVELSTATISTICS
 DESCRIPTOR.message_types_by_name['Assembly'] = _ASSEMBLY
 DESCRIPTOR.message_types_by_name['Taxon'] = _TAXON
 DESCRIPTOR.message_types_by_name['Release'] = _RELEASE
+DESCRIPTOR.message_types_by_name['DatasetInfos'] = _DATASETINFOS
 DESCRIPTOR.message_types_by_name['GenomeSequence'] = _GENOMESEQUENCE
 DESCRIPTOR.message_types_by_name['GenomeUUIDRequest'] = _GENOMEUUIDREQUEST
 DESCRIPTOR.message_types_by_name['AssemblyIDRequest'] = _ASSEMBLYIDREQUEST
@@ -984,6 +1152,7 @@ DESCRIPTOR.message_types_by_name['OrganismIDRequest'] = _ORGANISMIDREQUEST
 DESCRIPTOR.message_types_by_name['GenomeNameRequest'] = _GENOMENAMEREQUEST
 DESCRIPTOR.message_types_by_name['ReleaseRequest'] = _RELEASEREQUEST
 DESCRIPTOR.message_types_by_name['GenomeSequenceRequest'] = _GENOMESEQUENCEREQUEST
+DESCRIPTOR.message_types_by_name['GenomeDatatypeRequest'] = _GENOMEDATATYPEREQUEST
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 Genome = _reflection.GeneratedProtocolMessageType('Genome', (_message.Message,), {
@@ -1064,6 +1233,21 @@ Release = _reflection.GeneratedProtocolMessageType('Release', (_message.Message,
   })
 _sym_db.RegisterMessage(Release)
 
+DatasetInfos = _reflection.GeneratedProtocolMessageType('DatasetInfos', (_message.Message,), {
+
+  'DatasetInfo' : _reflection.GeneratedProtocolMessageType('DatasetInfo', (_message.Message,), {
+    'DESCRIPTOR' : _DATASETINFOS_DATASETINFO,
+    '__module__' : 'ensembl_metadata_pb2'
+    # @@protoc_insertion_point(class_scope:ensembl_metadata.DatasetInfos.DatasetInfo)
+    })
+  ,
+  'DESCRIPTOR' : _DATASETINFOS,
+  '__module__' : 'ensembl_metadata_pb2'
+  # @@protoc_insertion_point(class_scope:ensembl_metadata.DatasetInfos)
+  })
+_sym_db.RegisterMessage(DatasetInfos)
+_sym_db.RegisterMessage(DatasetInfos.DatasetInfo)
+
 GenomeSequence = _reflection.GeneratedProtocolMessageType('GenomeSequence', (_message.Message,), {
   'DESCRIPTOR' : _GENOMESEQUENCE,
   '__module__' : 'ensembl_metadata_pb2'
@@ -1113,6 +1297,13 @@ GenomeSequenceRequest = _reflection.GeneratedProtocolMessageType('GenomeSequence
   })
 _sym_db.RegisterMessage(GenomeSequenceRequest)
 
+GenomeDatatypeRequest = _reflection.GeneratedProtocolMessageType('GenomeDatatypeRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GENOMEDATATYPEREQUEST,
+  '__module__' : 'ensembl_metadata_pb2'
+  # @@protoc_insertion_point(class_scope:ensembl_metadata.GenomeDatatypeRequest)
+  })
+_sym_db.RegisterMessage(GenomeDatatypeRequest)
+
 
 
 _ENSEMBLMETADATA = _descriptor.ServiceDescriptor(
@@ -1122,8 +1313,8 @@ _ENSEMBLMETADATA = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=1912,
-  serialized_end=2939,
+  serialized_start=2275,
+  serialized_end=3402,
   methods=[
   _descriptor.MethodDescriptor(
     name='GetGenomeByUUID',
@@ -1232,6 +1423,16 @@ _ENSEMBLMETADATA = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_GENOMESEQUENCEREQUEST,
     output_type=_GENOMESEQUENCE,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='GetDatasetInformation',
+    full_name='ensembl_metadata.EnsemblMetadata.GetDatasetInformation',
+    index=11,
+    containing_service=None,
+    input_type=_GENOMEDATATYPEREQUEST,
+    output_type=_DATASETINFOS,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
   ),

--- a/src/ensembl/production/metadata/ensembl_metadata_pb2_grpc.py
+++ b/src/ensembl/production/metadata/ensembl_metadata_pb2_grpc.py
@@ -70,6 +70,11 @@ class EnsemblMetadataStub(object):
                 request_serializer=ensembl__metadata__pb2.GenomeSequenceRequest.SerializeToString,
                 response_deserializer=ensembl__metadata__pb2.GenomeSequence.FromString,
                 )
+        self.GetDatasetInformation = channel.unary_unary(
+                '/ensembl_metadata.EnsemblMetadata/GetDatasetInformation',
+                request_serializer=ensembl__metadata__pb2.GenomeDatatypeRequest.SerializeToString,
+                response_deserializer=ensembl__metadata__pb2.DatasetInfos.FromString,
+                )
 
 
 class EnsemblMetadataServicer(object):
@@ -153,6 +158,13 @@ class EnsemblMetadataServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def GetDatasetInformation(self, request, context):
+        """Retrieve dataset info by genome uuid and dataset_type
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_EnsemblMetadataServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -210,6 +222,11 @@ def add_EnsemblMetadataServicer_to_server(servicer, server):
                     servicer.GetGenomeSequence,
                     request_deserializer=ensembl__metadata__pb2.GenomeSequenceRequest.FromString,
                     response_serializer=ensembl__metadata__pb2.GenomeSequence.SerializeToString,
+            ),
+            'GetDatasetInformation': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetDatasetInformation,
+                    request_deserializer=ensembl__metadata__pb2.GenomeDatatypeRequest.FromString,
+                    response_serializer=ensembl__metadata__pb2.DatasetInfos.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -406,5 +423,22 @@ class EnsemblMetadata(object):
         return grpc.experimental.unary_stream(request, target, '/ensembl_metadata.EnsemblMetadata/GetGenomeSequence',
             ensembl__metadata__pb2.GenomeSequenceRequest.SerializeToString,
             ensembl__metadata__pb2.GenomeSequence.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def GetDatasetInformation(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/ensembl_metadata.EnsemblMetadata/GetDatasetInformation',
+            ensembl__metadata__pb2.GenomeDatatypeRequest.SerializeToString,
+            ensembl__metadata__pb2.DatasetInfos.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/src/ensembl/production/metadata/service.py
+++ b/src/ensembl/production/metadata/service.py
@@ -634,10 +634,14 @@ def create_release(data=None):
 
 
 def create_dataset_info(data=None):
+    if data is None:
+        return ensembl_metadata_pb2.DatasetInfos.DatasetInfo()
     return ensembl_metadata_pb2.DatasetInfos.DatasetInfo(**dict(data))
 
 
 def create_dataset_infos(genome_uuid, requested_dataset_type, data=None):
+    if data is None or data == []:
+        return ensembl_metadata_pb2.DatasetInfos()
     dataset_infos = [create_dataset_info(result) for result in data]
     return ensembl_metadata_pb2.DatasetInfos(
         genome_uuid=genome_uuid,

--- a/src/ensembl/production/metadata/service.py
+++ b/src/ensembl/production/metadata/service.py
@@ -458,6 +458,45 @@ def release_by_uuid_iterator(metadata_db, genome_uuid):
         yield create_release(dict(result))
 
 
+def get_dataset_by_genome_id(metadata_db, genome_uuid, requested_dataset_type):
+    # This is sqlalchemy's metadata, not Ensembl's!
+    md = db.MetaData()
+    session = Session(metadata_db, future=True)
+
+    # Reflect existing tables, letting sqlalchemy load linked tables where possible.
+    genome = db.Table('genome', md, autoload_with=metadata_db)
+    genome_dataset = db.Table('genome_dataset', md, autoload_with=metadata_db)
+    dataset = db.Table('dataset', md, autoload_with=metadata_db)
+    dataset_type = db.Table('dataset_type', md, autoload_with=metadata_db)
+    attribute = db.Table('attribute', md, autoload_with=metadata_db)
+    dataset_attribute = db.Table('dataset_attribute', md, autoload_with=metadata_db)
+    ensembl_release = db.Table('ensembl_release', md, autoload_with=metadata_db)
+
+    dataset_select = db.select(
+                               dataset.c.dataset_uuid,
+                               dataset.c.name.label('dataset_name'),
+                               attribute.c.name,
+                               dataset_attribute.c.type,
+                               dataset.c.version.label('dataset_version'),
+                               dataset.c.label.label('dataset_label'),
+                               ensembl_release.c.version,
+                               dataset_attribute.c.value
+                               ) \
+        .select_from(genome).filter_by(genome_uuid=genome_uuid) \
+        .join(genome_dataset) \
+        .join(ensembl_release) \
+        .join(dataset) \
+        .join(dataset_attribute) \
+        .join(attribute) \
+        .join(dataset_type) \
+        .where(dataset_type.c.name == requested_dataset_type) \
+        .order_by(dataset_type.c.name, dataset.c.name) \
+        .distinct()
+
+    dataset_results = session.execute(dataset_select).all()
+    return create_dataset_infos(genome_uuid, requested_dataset_type, dataset_results)
+
+
 def create_species(data=None):
     if data is None:
         return ensembl_metadata_pb2.Species()
@@ -594,6 +633,19 @@ def create_release(data=None):
     return release
 
 
+def create_dataset_info(data=None):
+    return ensembl_metadata_pb2.DatasetInfos.DatasetInfo(**dict(data))
+
+
+def create_dataset_infos(genome_uuid, requested_dataset_type, data=None):
+    dataset_infos = [create_dataset_info(result) for result in data]
+    return ensembl_metadata_pb2.DatasetInfos(
+        genome_uuid=genome_uuid,
+        dataset_type=requested_dataset_type,
+        dataset_infos=dataset_infos
+    )
+
+
 class EnsemblMetadataServicer(ensembl_metadata_pb2_grpc.EnsemblMetadataServicer):
     def __init__(self):
         self.db, self.taxo_db = load_database()
@@ -645,6 +697,9 @@ class EnsemblMetadataServicer(ensembl_metadata_pb2_grpc.EnsemblMetadataServicer)
                                         request.genome_uuid,
                                         request.chromosomal_only
                                         )
+
+    def GetDatasetInformation(self, request, context):
+        return get_dataset_by_genome_id(self.db, request.genome_uuid, request.dataset_type)
 
 
 def serve():

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -335,3 +335,10 @@ class TestClass:
                                   'value': '2379995981'
                               }]
                           }
+
+
+    def test_get_dataset_by_genome_id_no_results(self):
+        output = json_format.MessageToJson(
+            service.get_dataset_by_genome_id(self.engine, '3c4cec7f-fb69-11eb-8dac-005056b32883', 'blah blah blah'))
+        output = json.loads(output)
+        assert output == {}

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -318,3 +318,20 @@ class TestClass:
             'statisticType': "count",
             'statisticValue': "22"
         }
+
+
+    def test_get_dataset_by_genome_id(self):
+        output = json_format.MessageToJson(service.get_dataset_by_genome_id(self.engine, '3c4cec7f-fb69-11eb-8dac-005056b32883', 'assembly'))
+        output = json.loads(output)
+        assert output == {'genomeUuid': '3c4cec7f-fb69-11eb-8dac-005056b32883', 'datasetType': 'assembly',
+                          'datasetInfos': [
+                              {
+                                  'datasetUuid': '40a98446-fb69-11eb-8dac-005056b32883',
+                                  'datasetName': 'assembly',
+                                  'name': 'ungapped_genome',
+                                  'type': 'length_bp',
+                                  'datasetLabel': 'GCA_009873245.2',
+                                  'version': 22,
+                                  'value': '2379995981'
+                              }]
+                          }


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-964
https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-8011

This adds an RPC method to get dataset info by genome_id and datatype.

**Example**
User request:
```python
service.get_dataset_by_genome_id(self.engine, '3c4cec7f-fb69-11eb-8dac-005056b32883', 'assembly')
```

Response (in JSON):

```json
{
  "genomeUuid": "3c4cec7f-fb69-11eb-8dac-005056b32883",
  "datasetType": "assembly",
  "datasetInfos": [
    {
      "datasetUuid": "40a98446-fb69-11eb-8dac-005056b32883",
      "datasetName": "assembly",
      "name": "ungapped_genome",
      "type": "length_bp",
      "datasetLabel": "GCA_009873245.2",
      "version": 22,
      "value": "2379995981"
    }
  ]
}
```

