### PR TITLE
Fetch unreleased data only if required internally (gRPC changes)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ sqlalchemy==1.4.21
     # via -r requirements.in
 types-pymysql==1.0.0
     # via -r requirements.in
-ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@hotfix/alter_unreleased_logic
+ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@main
     # via -r requirements.in
 ensembl-py @ git+https://github.com/Ensembl/ensembl-py.git@1.1.0.dev3
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ sqlalchemy==1.4.21
     # via -r requirements.in
 types-pymysql==1.0.0
     # via -r requirements.in
-ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@main
+ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@hotfix/alter_unreleased_logic
     # via -r requirements.in
 ensembl-py @ git+https://github.com/Ensembl/ensembl-py.git@1.1.0.dev3
 # The following packages are considered to be unsafe in a requirements file:

--- a/src/ensembl/production/metadata/grpc/client_examples.py
+++ b/src/ensembl/production/metadata/grpc/client_examples.py
@@ -213,10 +213,17 @@ def get_top_level_statistics_by_uuid(stub):
 
 def get_datasets_list_by_uuid(stub):
     request1 = DatasetsRequest(
+        genome_uuid="a7335667-93e7-11ec-a39d-005056b38ce3"
+    )
+    request2 = DatasetsRequest(
         genome_uuid="a7335667-93e7-11ec-a39d-005056b38ce3", release_version=108.0
     )
-    datasets = stub.GetDatasetsListByUUID(request1)
-    print(datasets)
+    print("**** Release not specified ****")
+    datasets1 = stub.GetDatasetsListByUUID(request1)
+    print(datasets1)
+    print("**** Release specified ****")
+    datasets2 = stub.GetDatasetsListByUUID(request2)
+    print(datasets2)
 
 
 def get_dataset_infos_by_dataset_type(stub):

--- a/src/ensembl/production/metadata/grpc/config.py
+++ b/src/ensembl/production/metadata/grpc/config.py
@@ -18,4 +18,4 @@ class MetadataConfig:
     pool_size = os.environ.get("POOL_SIZE", 20)
     max_overflow = os.environ.get("MAX_OVERFLOW", 0)
 
-    unreleased_data_only = os.environ.get("UNRELEASED_DATA_ONLY", False)
+    allow_unreleased = os.environ.get("ALLOW_UNRELEASED", False)

--- a/src/ensembl/production/metadata/grpc/config.py
+++ b/src/ensembl/production/metadata/grpc/config.py
@@ -17,3 +17,5 @@ class MetadataConfig:
     taxon_uri = os.environ.get("TAXONOMY_URI", f"mysql+pymysql://ensembl@localhost:3306/ncbi_taxonomy")
     pool_size = os.environ.get("POOL_SIZE", 20)
     max_overflow = os.environ.get("MAX_OVERFLOW", 0)
+
+    unreleased_data_only = os.environ.get("UNRELEASED_DATA_ONLY", False)

--- a/src/ensembl/production/metadata/grpc/utils.py
+++ b/src/ensembl/production/metadata/grpc/utils.py
@@ -38,7 +38,8 @@ def get_karyotype_information(db_conn, genome_uuid):
     karyotype_info_result = db_conn.fetch_sequences(
         genome_uuid=genome_uuid
     )
-
+    # Wow! this returns 109583 rows for 'a7335667-93e7-11ec-a39d-005056b38ce3'
+    # TODO: Understand what's going on
     if len(karyotype_info_result) == 1:
         return create_karyotype(karyotype_info_result[0])
 
@@ -51,7 +52,8 @@ def get_top_level_statistics(db_conn, organism_uuid, group):
 
     stats_results = db_conn.fetch_genome_datasets(
         organism_uuid=organism_uuid,
-        dataset_name="all"
+        dataset_name="all",
+        dataset_attributes=True
     )
 
     statistics = []
@@ -77,7 +79,8 @@ def get_top_level_statistics_by_uuid(db_conn, genome_uuid):
 
     stats_results = db_conn.fetch_genome_datasets(
         genome_uuid=genome_uuid,
-        dataset_name="all"
+        dataset_name="all",
+        dataset_attributes=True
     )
 
     statistics = []
@@ -115,7 +118,7 @@ def get_genomes_from_assembly_accession_iterator(db_conn, assembly_accession):
 
     genome_results = db_conn.fetch_genomes(
         assembly_accession=assembly_accession,
-        unreleased_only=cfg.unreleased_data_only
+        allow_unreleased=cfg.allow_unreleased
     )
     for genome in genome_results:
         yield create_genome(genome)
@@ -127,7 +130,7 @@ def get_species_information(db_conn, genome_uuid):
 
     species_results = db_conn.fetch_genomes(
         genome_uuid=genome_uuid,
-        unreleased_only=cfg.unreleased_data_only
+        allow_unreleased=cfg.allow_unreleased
     )
     if len(species_results) == 1:
         tax_id = species_results[0].Organism.taxonomy_id
@@ -144,7 +147,7 @@ def get_sub_species_info(db_conn, organism_uuid, group):
     sub_species_results = db_conn.fetch_genomes(
         organism_uuid=organism_uuid,
         group=group,
-        unreleased_only=cfg.unreleased_data_only
+        allow_unreleased=cfg.allow_unreleased
     )
 
     species_name = []
@@ -173,7 +176,7 @@ def get_genome_uuid(db_conn, ensembl_name, assembly_name, use_default=False):
         ensembl_name=ensembl_name,
         assembly_name=assembly_name,
         use_default_assembly=use_default,
-        unreleased_only=cfg.unreleased_data_only
+        allow_unreleased=cfg.allow_unreleased
     )
 
     if len(genome_uuid_result) == 1:
@@ -191,7 +194,7 @@ def get_genome_by_uuid(db_conn, genome_uuid, release_version):
     genome_results = db_conn.fetch_genomes(
         genome_uuid=genome_uuid,
         release_version=release_version,
-        unreleased_only=cfg.unreleased_data_only
+        allow_unreleased=cfg.allow_unreleased
     )
 
     if len(genome_results) == 1:
@@ -234,7 +237,7 @@ def get_genome_by_name(db_conn, ensembl_name, site_name, release_version):
         ensembl_name=ensembl_name,
         site_name=site_name,
         release_version=release_version,
-        unreleased_only=cfg.unreleased_data_only
+        allow_unreleased=cfg.allow_unreleased
     )
     if len(genome_results) == 1:
         return create_genome(genome_results[0])
@@ -250,7 +253,8 @@ def get_datasets_list_by_uuid(db_conn, genome_uuid, release_version):
         # fetch all datasets, default is 'assembly' only
         dataset_name="all",
         release_version=release_version,
-        unreleased_datasets=cfg.unreleased_data_only
+        allow_unreleased=cfg.allow_unreleased,
+        dataset_attributes=True
     )
 
     if len(datasets_results) > 0:
@@ -330,6 +334,7 @@ def get_dataset_by_genome_and_dataset_type(db_conn, genome_uuid, requested_datas
 
     dataset_results = db_conn.fetch_genome_datasets(
         genome_uuid=genome_uuid,
-        dataset_type=requested_dataset_type
+        dataset_type=requested_dataset_type,
+        dataset_attributes=True
     )
     return create_dataset_infos(genome_uuid, requested_dataset_type, dataset_results)

--- a/src/ensembl/production/metadata/grpc/utils.py
+++ b/src/ensembl/production/metadata/grpc/utils.py
@@ -114,7 +114,8 @@ def get_genomes_from_assembly_accession_iterator(db_conn, assembly_accession):
         return create_genome()
 
     genome_results = db_conn.fetch_genomes(
-        assembly_accession=assembly_accession
+        assembly_accession=assembly_accession,
+        unreleased_only=cfg.unreleased_data_only
     )
     for genome in genome_results:
         yield create_genome(genome)
@@ -125,7 +126,8 @@ def get_species_information(db_conn, genome_uuid):
         return create_species()
 
     species_results = db_conn.fetch_genomes(
-        genome_uuid=genome_uuid
+        genome_uuid=genome_uuid,
+        unreleased_only=cfg.unreleased_data_only
     )
     if len(species_results) == 1:
         tax_id = species_results[0].Organism.taxonomy_id
@@ -141,7 +143,8 @@ def get_sub_species_info(db_conn, organism_uuid, group):
 
     sub_species_results = db_conn.fetch_genomes(
         organism_uuid=organism_uuid,
-        group=group
+        group=group,
+        unreleased_only=cfg.unreleased_data_only
     )
 
     species_name = []
@@ -169,7 +172,8 @@ def get_genome_uuid(db_conn, ensembl_name, assembly_name, use_default=False):
     genome_uuid_result = db_conn.fetch_genomes(
         ensembl_name=ensembl_name,
         assembly_name=assembly_name,
-        use_default_assembly=use_default
+        use_default_assembly=use_default,
+        unreleased_only=cfg.unreleased_data_only
     )
 
     if len(genome_uuid_result) == 1:
@@ -186,7 +190,8 @@ def get_genome_by_uuid(db_conn, genome_uuid, release_version):
 
     genome_results = db_conn.fetch_genomes(
         genome_uuid=genome_uuid,
-        release_version=release_version
+        release_version=release_version,
+        unreleased_only=cfg.unreleased_data_only
     )
 
     if len(genome_results) == 1:
@@ -228,14 +233,15 @@ def get_genome_by_name(db_conn, ensembl_name, site_name, release_version):
     genome_results = db_conn.fetch_genomes(
         ensembl_name=ensembl_name,
         site_name=site_name,
-        release_version=release_version
+        release_version=release_version,
+        unreleased_only=cfg.unreleased_data_only
     )
     if len(genome_results) == 1:
         return create_genome(genome_results[0])
     return create_genome()
 
 
-def get_datasets_list_by_uuid(db_conn, genome_uuid, release_version=0):
+def get_datasets_list_by_uuid(db_conn, genome_uuid, release_version):
     if genome_uuid is None:
         return create_datasets()
 
@@ -243,7 +249,8 @@ def get_datasets_list_by_uuid(db_conn, genome_uuid, release_version=0):
         genome_uuid=genome_uuid,
         # fetch all datasets, default is 'assembly' only
         dataset_name="all",
-        release_version=release_version
+        release_version=release_version,
+        unreleased_datasets=cfg.unreleased_data_only
     )
 
     if len(datasets_results) > 0:

--- a/src/tests/test_protobuf_msg_factory.py
+++ b/src/tests/test_protobuf_msg_factory.py
@@ -118,6 +118,7 @@ class TestClass:
         organism_uuid = "21279e3e-e651-43e1-a6fc-79e390b9e8a8"
         input_data = genome_db_conn.fetch_genome_datasets(
             organism_uuid=organism_uuid,
+            dataset_attributes=True,
             dataset_name="all"
         )
 

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -159,7 +159,7 @@ class TestUtils:
         # because of the returned attributes
         # TODO: Fix this later
         output = json_format.MessageToJson(
-            utils.get_datasets_list_by_uuid(genome_db_conn, "a73357ab-93e7-11ec-a39d-005056b38ce3"))
+            utils.get_datasets_list_by_uuid(genome_db_conn, "a73357ab-93e7-11ec-a39d-005056b38ce3", 108.0))
 
         expected_output = {
             "genomeUuid": "a73357ab-93e7-11ec-a39d-005056b38ce3",

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -502,7 +502,6 @@ class TestUtils:
         assert output == expected_output
 
     def test_get_dataset_by_genome_and_dataset_type(self, genome_db_conn):
-        # TODO: Fix
         output = json_format.MessageToJson(
             utils.get_dataset_by_genome_and_dataset_type(genome_db_conn, "a7335667-93e7-11ec-a39d-005056b38ce3",
                                                          "assembly")


### PR DESCRIPTION
### JIRA Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1109

### Changes
Update the API to fetch unreleased data only if required internally using `UNRELEASED_DATA_ONLY` environment variable.

### Related PR:
https://github.com/Ensembl/ensembl-metadata-api/pull/36