### PR TITLE
Optimize Genome Query

### DIFF
--- a/src/ensembl/production/metadata/grpc/utils.py
+++ b/src/ensembl/production/metadata/grpc/utils.py
@@ -131,9 +131,9 @@ def get_genomes_from_assembly_accession_iterator(db_conn, assembly_accession, re
         allow_unreleased=cfg.allow_unreleased
     )
     for genome in genome_results:
-        yield create_genome_with_attributes_and_count(
-            db_conn=db_conn, genome=genome, release_version=release_version
-        )
+        yield msg_factory.create_genome(data=genome)
+
+    return msg_factory.create_genome()
 
 def get_species_information(db_conn, genome_uuid):
     if genome_uuid is None:
@@ -251,9 +251,7 @@ def get_genomes_by_keyword_iterator(db_conn, keyword, release_version):
             most_recent_genomes.append(most_recent_genome)
 
         for genome_row in most_recent_genomes:
-            yield create_genome_with_attributes_and_count(
-                db_conn=db_conn, genome=genome_row, release_version=release_version
-            )
+            yield msg_factory.create_genome(data=genome_row)
 
         return msg_factory.create_genome()
 

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -974,7 +974,6 @@ class TestUtils:
 				}
 			}
 		]
-		print(output)
 		assert output == expected_output
 
 	def test_get_genomes_by_keyword_null(self, genome_db_conn):

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -104,7 +104,6 @@ class TestUtils:
 					"speciesTaxonomyId": 562,
 					"taxonomyId": 511145
 				},
-				"relatedAssembliesCount": 1,
 				"release": {
 					"isCurrent": True,
 					"releaseDate": "2023-05-15",
@@ -115,12 +114,6 @@ class TestUtils:
 					"siteUri": "https://beta.ensembl.org"
 				},
 				"taxon": {
-					"alternativeNames": [
-						"Escherichia coli MG1655",
-						"Escherichia coli str. K12 substr. MG1655",
-						"Escherichia coli str. MG1655",
-						"Escherichia coli strain MG1655",
-					],
 					"scientificName": "Escherichia coli str. K-12 substr. MG1655 str. K12 (GCA_000005845)",
 					"taxonomyId": 511145
 				}
@@ -837,10 +830,7 @@ class TestUtils:
 					"ucscName": "hg38",
 					"urlName": "GRCh38"
 				},
-				"attributesInfo": {
-					"assemblyDate": "2013-12",
-					"assemblyLevel": "chromosome"
-				},
+				"attributesInfo": {},
 				"created": "2023-05-12 13:30:58",
 				"genomeUuid": "a7335667-93e7-11ec-a39d-005056b38ce3",
 				"organism": {
@@ -862,11 +852,9 @@ class TestUtils:
 					"siteUri": "https://beta.ensembl.org"
 				},
 				"taxon": {
-					"alternativeNames": ["human"],
 					"scientificName": "Homo sapiens",
 					"taxonomyId": 9606
 				},
-				"relatedAssembliesCount": 3,
 			},
 			{
 				"assembly": {
@@ -890,7 +878,6 @@ class TestUtils:
 					"taxonomyId": 9606,
 					"scientificParlanceName": "homo_sapiens"
 				},
-				"relatedAssembliesCount": 3,
 				"release": {
 					"isCurrent": True,
 					"releaseDate": "2023-05-15",
@@ -901,7 +888,6 @@ class TestUtils:
 					"siteUri": "https://beta.ensembl.org"
 				},
 				"taxon": {
-					"alternativeNames": ["human"],
 					"scientificName": "Homo sapiens",
 					"taxonomyId": 9606
 				}
@@ -925,10 +911,7 @@ class TestUtils:
 					"ucscName": "hg38",
 					"urlName": "GRCh38"
 				},
-				"attributesInfo": {
-					"assemblyDate": "2013-12",
-					"assemblyLevel": "chromosome"
-				},
+				"attributesInfo": {},
 				"created": "2023-05-12 13:30:58",
 				"genomeUuid": "a7335667-93e7-11ec-a39d-005056b38ce3",
 				"organism": {
@@ -950,11 +933,9 @@ class TestUtils:
 					"siteUri": "https://beta.ensembl.org"
 				},
 				"taxon": {
-					"alternativeNames": ["human"],
 					"scientificName": "Homo sapiens",
 					"taxonomyId": 9606
 				},
-				"relatedAssembliesCount": 3,
 			},
 			{
 				"assembly": {
@@ -978,7 +959,6 @@ class TestUtils:
 					"taxonomyId": 9606,
 					"scientificParlanceName": "homo_sapiens"
 				},
-				"relatedAssembliesCount": 3,
 				"release": {
 					"isCurrent": True,
 					"releaseDate": "2023-05-15",
@@ -989,12 +969,12 @@ class TestUtils:
 					"siteUri": "https://beta.ensembl.org"
 				},
 				"taxon": {
-					"alternativeNames": ["human"],
 					"scientificName": "Homo sapiens",
 					"taxonomyId": 9606
 				}
 			}
 		]
+		print(output)
 		assert output == expected_output
 
 	def test_get_genomes_by_keyword_null(self, genome_db_conn):


### PR DESCRIPTION
### JIRA Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1145

### Changes
Thoas' `genomes by_keyword` gRPC is slow (was taking **~20 seconds**)
```
query {
  genomes(
    by_keyword: {
      keyword:"Human"
    }
  ) {
    genome_id
    assembly_accession
    scientific_name
    release_number
  }
}
```
Because it was using `create_genome_with_attributes_and_count()` function which gets extra data (for each genome) that we don't need here (`create_genome()` function is enough) -> now it's taking **0.1 second**